### PR TITLE
improve golang ci workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,8 +1,8 @@
-name: Unit Test
+name: Lint
 on: [push]
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -19,5 +19,7 @@ jobs:
           ${{ runner.os }}-go-
     - name: Run go mod download
       run: go mod download
-    - name: test
-      run: go test -v ./...
+    - name: Run go vet
+      run: go vet ./...
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2


### PR DESCRIPTION
## Why

<!-- Why need this Pull Request ? -->
If linter failure in now workflow, unit testing is not tested.
In addition, It's better to use other static analysis tools, too.
For example `go vet`.

## How

<!-- How do you realize? -->
I split now workflow into `Linter` and `Unit Test`.
`Linter` job run `golangci-lint` and `go vet`.

## References

<!-- related infomation -->
#7 